### PR TITLE
improve deno compatibility

### DIFF
--- a/packages/server/src/db/db.server.ts
+++ b/packages/server/src/db/db.server.ts
@@ -1,7 +1,7 @@
 import { drizzle, LibSQLDatabase } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
-import { mkdirSync } from "fs";
-import { join, resolve } from "path";
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { __dirnameFromImportMetaUrl } from "../utils/dirname";
 
 const __dirname = __dirnameFromImportMetaUrl(import.meta.url);

--- a/packages/server/src/hono.ts
+++ b/packages/server/src/hono.ts
@@ -1,5 +1,5 @@
 import { getRequestListener, type HttpBindings } from "@hono/node-server";
-import { type ServerResponse } from "http";
+import { type ServerResponse } from "node:http";
 import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { env } from "./lib/env.server";

--- a/packages/server/src/lib/integrations/toggl.ts
+++ b/packages/server/src/lib/integrations/toggl.ts
@@ -3,7 +3,7 @@ import { Integration } from "../integration-types";
 import { Dataset, Row } from "@mainframe-so/shared";
 import { syncTable, updateObject, updateRowFromTableType } from "../../sync";
 import { getDatasetObject, getDatasetTable } from "../integrations";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import { objectsTable, rowsTable, tablesTable } from "@mainframe-so/shared";
 import { and, eq } from "drizzle-orm";
 import { deserialize } from "../../utils/serialization";

--- a/packages/server/src/lib/llm/openai.ts
+++ b/packages/server/src/lib/llm/openai.ts
@@ -1,10 +1,10 @@
 import { env } from "../env.server";
 import jsonToTS from "json-to-ts";
 import { once } from "lodash";
-import { readFile } from "fs/promises";
+import { readFile } from "node:fs/promises";
 import OpenAI from "openai";
 import { __dirnameFromImportMetaUrl } from "../../utils/dirname";
-import { resolve } from "path";
+import { resolve } from "node:path";
 
 const __dirname = __dirnameFromImportMetaUrl(import.meta.url);
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,7 +8,7 @@ import express, { Express } from "express";
 import { json, text } from "body-parser";
 import { env } from "./lib/env.server";
 import { ZodError } from "zod";
-import type { Server } from "http";
+import type { Server } from "node:http";
 import { syncAll } from "./sync";
 import { datasetsTable } from "@mainframe-so/shared";
 import { eq } from "drizzle-orm";

--- a/packages/server/src/utils/dirname.ts
+++ b/packages/server/src/utils/dirname.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from "url";
-import path from "path";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 export function __dirnameFromImportMetaUrl(url: string) {
   return path.dirname(fileURLToPath(url));

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,7 @@
     "publish-package": "npm publish"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./dist/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR tries to make mainframe.so runnable using the deno runtime.

This is the first step before trying to integrate it with [smallweb](https://github.com/pomdtr/smallweb)